### PR TITLE
fix(build-trigger): Only trigger on changes to source

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: "Build"
 on:
-  pull_request:
   push:
-    branches: master
     paths:
     - examples/*
     - examples/*/*


### PR DESCRIPTION
Only trigger builds on changes to the source examples, and not docs/metadata updates.